### PR TITLE
Upgrade suspend module to 0.7.0 to be able to build with npm3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/ddsol/mp3-duration",
   "dependencies": {
-    "suspend": "^0.6.1",
+    "suspend": "^0.7.0",
     "thunkify": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
After I upgraded to npm3, I encountered this error

    Error: Cannot find module '../node_modules/promise/lib/es6-extensions'

After a bit research, I found it could be easily fixed by updating the suspend module
[REF] https://github.com/jmar777/suspend/issues/27