### PR TITLE
npm3 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var fs = require('fs'),
     suspend = require('suspend'),
-    thunkify = require('thunkify');
+    promisify = require('es6-promisify');
 
-var $open=thunkify(fs.open),   //(filename, flags [, mode])
-    $read=thunkify(fs.read).bind(fs),   //(fd, buffer, bufferOffset, length, position)
-    $fstat=thunkify(fs.fstat).bind(fs), //(fs)
-    $close=thunkify(fs.close).bind(fs);
+var $open=promisify(fs.open),   //(filename, flags [, mode])
+    $read=promisify(fs.read).bind(fs),   //(fd, buffer, bufferOffset, length, position)
+    $fstat=promisify(fs.fstat).bind(fs), //(fs)
+    $close=promisify(fs.close).bind(fs);
 
 function skipId3(buffer) {
     var id3v2Flags,  z0, z1, z2, z3, tagSize, footerSize;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mp3-duration",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Get the duration of an MP3 file",
   "main": "index.js",
   "scripts": {
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/ddsol/mp3-duration",
   "dependencies": {
+    "es6-promisify": "^3.0.0",
     "suspend": "^0.7.0",
     "thunkify": "^2.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/ddsol/mp3-duration",
   "dependencies": {
-    "suspend": "^0.6.1",
+    "suspend": "^0.7.0",
     "thunkify": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I've replaced thunkify to promisify and now it is passing the tests.

After I upgraded to npm3, I encountered this error

    Error: Cannot find module '../node_modules/promise/lib/es6-extensions'

After a bit research, I found it could be easily fixed by updating the suspend module
[REF] https://github.com/jmar777/suspend/issues/27