### PR TITLE
Added support for buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,6 @@ function mp3Duration(filename, cbrEstimate, callback) {
       offset = skipId3(buffer);
 
       while (offset < (isBuffer ? srcBuffer.length : stat.size)) {
-        //console.log('WHile')
         if (!isBuffer) {
           bytesRead = yield $read(fd, buffer, 0, 10, offset);
         } else {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-    mp3Duration=require('../index.js');
+    mp3Duration=require('../index.js'),
+    fs = require('fs');
 
 describe('mp3Duration', function () {
 
@@ -22,6 +23,27 @@ describe('mp3Duration', function () {
 
   it('returns a correct value for CBR duration without estimate', function (done) {
     mp3Duration('./tests/demo - cbr.mp3', function (err, length) {
+      assert.equal(err, null, (err || {}).message);
+      assert.equal(length, 285.78, 'Length not as expected');
+      done();
+    });
+  });
+
+  it('returns a correct value for VBR duration when passing a buffer instead of a filename', function (done) {
+    const buffer = fs.readFileSync('./tests/demo - vbr.mp3');
+
+    mp3Duration(buffer, function (err, length) {
+      if (err) console.log(err.stack);
+      assert.equal(err, null, (err || {}).message);
+      assert.equal(length, 285.727, 'Length not as expected');
+      done();
+    });
+  });
+
+  it('return a correct value for CBR duration without estimate when passing a buffer instead of a filename', function (done) {
+    const buffer = fs.readFileSync('./tests/demo - cbr.mp3');
+
+    mp3Duration(buffer, function (err, length) {
       assert.equal(err, null, (err || {}).message);
       assert.equal(length, 285.78, 'Length not as expected');
       done();


### PR DESCRIPTION
`mp3Duration()` now acceptes either a filename or a buffer.
This can be important if the file already has been read into the memory or saving files in production environment is restricted/not supported.