### PR TITLE
Drop bluebird/co, switch to async function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - '0.12'
+  - '8'
+  - 'node'

--- a/README.md
+++ b/README.md
@@ -2,51 +2,59 @@
 
 > Calculate duration of an MP3
 
-
 ## Install
 
-```
-$ npm install --save mp3-duration
+```sh
+npm install mp3-duration
 ```
 
 ## Usage
 
+1. JavaScript
+
 ```javascript
 var mp3Duration = require('mp3-duration');
 
-mp3Duration('file.mp3', function (err, duration) {
-  if (err) return console.log(err.message);
-  console.log('Your file is ' + duration + ' seconds long');
+mp3Duration('file.mp3').then(duration => {
+  console.log(`Your file is ${duration} seconds long`);
+}).catch(e => {
+  console.err(e);
+});
+```
+
+2. TypeScript
+
+```typescript
+import mp3Duration = require('mp3-duration');
+
+mp3Duration('file.mp3').then(duration => {
+  console.log(`Your file is ${duration} seconds long`);
+}).catch(e => {
+  console.err(e);
 });
 ```
 
 ## API
 
-## mp3Duration(filePathOrBuffer [, cbrEstimate] [, callback])
+## mp3Duration(filePathOrBuffer [, cbrEstimate])
 
 ### filePathOrBuffer
 
-Type: `string` | `Buffer`
+Type: `string | Buffer`
 
 Path to the file or a buffer with the file's contents
 
 ### cbrEstimate
 
+Type: `boolean`
+
 Defaults to `false`. When set to `true`, will estimate the length of a
 constant-bitrate mp3. This speeds up the calculation a lot but isn't
 guaranteed to be accurate.
 
-### callback(error, duration)
-
-Type: `function`
-
-Callback to be called once duration is calculated. It's also possible to
-instead use the returned `Promise`. `duration` is the duration of the
-mp3 in `ms`.
-
 ### Return value
 
-`mp3Duration` returns a Promise that resolves to the duration of the mp3 in `ms` or rejects with some error.
+`mp3Duration` returns a Promise that resolves to the duration of the mp3 in `second` or rejects with some error.
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare function mp3Duration(filePathOrBuffer: string | Buffer , cbrEstimate?: boolean): Promise<number>;
+declare function mp3Duration(filePathOrBuffer: string | Buffer): Promise<number>;
+
+export = mp3Duration;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/ddsol/mp3-duration"
   },
   "engines": {
-    "node": ">=0.11.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "mp3",
@@ -27,11 +27,10 @@
   },
   "homepage": "https://github.com/ddsol/mp3-duration",
   "dependencies": {
-    "bluebird": "^3.5.1",
-    "bluebird-co": "^2.2.0"
+    "@types/node": ">=8.0.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.4",
+    "mocha": "^5.2.0",
     "nyc": "^11.2.1"
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,52 +2,35 @@ var assert = require('assert'),
   mp3Duration = require('../index.js'),
   fs = require('fs');
 
-describe('mp3Duration', function() {
+describe('mp3Duration', function () {
 
-  it('returns a correct value for VBR duration', function(done) {
-    mp3Duration('./tests/demo - vbr.mp3', function(err, length) {
-      if (err) console.log(err.stack);
-      assert.equal(err, null, (err || {}).message);
-      assert.equal(length, 285.727, 'Length not as expected');
-      done();
-    });
+  it('returns a correct value for VBR duration', async () => {
+    const length = await mp3Duration('./tests/demo - vbr.mp3');
+    assert.equal(length, 285.727, 'Length not as expected');
   });
 
-  it('returns a correct value for CBR duration with estimate', function(done) {
-    mp3Duration('./tests/demo - cbr.mp3', true, function(err, length) {
-      assert.equal(err, null, (err || {}).message);
-      assert.equal(length, 285.727, 'Length not as expected');
-      done();
-    });
+  it('returns a correct value for CBR duration with estimate', async () => {
+    const length = await mp3Duration('./tests/demo - cbr.mp3', true);
+    assert.equal(length, 285.727, 'Length not as expected');
   });
 
-  it('returns a correct value for CBR duration without estimate', function(done) {
-    mp3Duration('./tests/demo - cbr.mp3', function(err, length) {
-      assert.equal(err, null, (err || {}).message);
-      assert.equal(length, 285.78, 'Length not as expected');
-      done();
-    });
+  it('returns a correct value for CBR duration without estimate', async () => {
+    const length = await mp3Duration('./tests/demo - cbr.mp3');
+    assert.equal(length, 285.78, 'Length not as expected');
   });
 
-  it('returns a correct value for VBR duration when passing a buffer instead of a filename', function(done) {
+  it('returns a correct value for VBR duration when passing a buffer instead of a filename', async () => {
     const buffer = fs.readFileSync('./tests/demo - vbr.mp3');
 
-    mp3Duration(buffer, function(err, length) {
-      if (err) console.log(err.stack);
-      assert.equal(err, null, (err || {}).message);
-      assert.equal(length, 285.727, 'Length not as expected');
-      done();
-    });
+    const length = await mp3Duration(buffer);
+    assert.equal(length, 285.727, 'Length not as expected');
   });
 
-  it('return a correct value for CBR duration without estimate when passing a buffer instead of a filename', function(done) {
+  it('return a correct value for CBR duration without estimate when passing a buffer instead of a filename', async () => {
     const buffer = fs.readFileSync('./tests/demo - cbr.mp3');
 
-    mp3Duration(buffer, function(err, length) {
-      assert.equal(err, null, (err || {}).message);
-      assert.equal(length, 285.78, 'Length not as expected');
-      done();
-    });
+    const length = await mp3Duration(buffer);
+    assert.equal(length, 285.78, 'Length not as expected');
   });
 
 });


### PR DESCRIPTION
Async functions are directly supported by NodeJS for quite a while. It's time to drop bluebird and and co.

Tests and CI configuration have been updated, and `.d.ts` type declaration file has been created too.